### PR TITLE
Add bounds-to-constraints reformulation option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,53 @@ All notable changes to SyntheticLPs.jl will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2026-06-29 17:26 EDT (bounds-to-constraints reformulation)
+
+**Previous Commit**: `c617dd7`
+
+**Summary**: Added an opt-in reformulation that rewrites variable bounds as
+explicit affine constraints, plumbed through the whole generation stack as the
+keyword `bounds_to_constraints` (default `false`, so the corpus is byte-identical
+when unused). Also fixed a pre-existing soft-scope bug in
+`scripts/generate_problem.jl` that silently dropped its `--feasible`/`--infeasible`,
+`--seed=`, and output-file arguments.
+
+**Details**:
+
+- **New file `src/transforms.jl`** — home for post-`build_model` model
+  reformulations, applied centrally in `generate_problem` (not per-variant),
+  the same way JuMP's `relax_integrality` is. Exports `bounds_to_constraints!`.
+- **`bounds_to_constraints!(model)`** — walks every variable and converts its
+  bounds to affine rows: a fixed value becomes an equality row, an upper bound
+  and a *nonzero* lower bound become inequality rows, and the corresponding
+  variable bound is removed. A plain `x ≥ 0` nonnegativity lower bound is left as
+  a variable bound (standard form), so only the "interesting" bounds are moved.
+- **Wiring** — `bounds_to_constraints::Bool=false` keyword added to all four
+  `generate_problem` methods, `generate_random_problem`, and `generate_dataset`
+  (threaded through its candidate/materialize helpers alongside `relax_integer`).
+  Applied *after* integrality relaxation so bounds introduced by relaxing
+  integer/binary variables (e.g. `0 ≤ x ≤ 1`) are converted too. Recorded in the
+  dataset `manifest.json` config and in verbose output.
+- **CLI** — `--bounds-to-constraints` flag on both `scripts/generate_problem.jl`
+  and `scripts/generate_lps.jl`.
+- **Side effect (intended)** — converted bounds become genuine constraint rows,
+  so they are now counted by
+  `num_constraints(model; count_variable_in_set_constraints=false)`. This raises
+  the recorded `num_constraints` per instance and therefore feeds into dataset
+  size-matching and the quality filter's constraint-based thresholds
+  (`min_constraints`, `max_iteration_ratio`).
+- **Bug fix** — `scripts/generate_problem.jl` parsed its optional arguments in a
+  top-level `for` loop whose assignments fell into Julia soft scope and became
+  new locals, so `--feasible`/`--infeasible`/`--unknown`, `--seed=`, and the
+  output-file positional were silently ignored. Added the required `global`
+  declaration; these flags now take effect.
+- **Tests** — new `Bounds to Constraints` testset: direct structural checks on
+  `bounds_to_constraints!` (nonnegativity preserved, other bounds become the
+  right number of rows, variable count unchanged), plus `generate_problem` and
+  `generate_dataset` integration (constraint counts increase, manifest flag set).
+  Suite now 2460 passing assertions (up from 2448); the 6 pre-existing
+  variable-count-tolerance failures are unchanged and unrelated.
+
 ## 2026-06-20 19:10 EDT (address PR #19 review feedback)
 
 **Previous Commit**: `f7a657f`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,6 +85,10 @@ SyntheticLPs uses a type-based dispatch system for generating realistic linear p
 - Random problem generation with `generate_random_problem()` (returns the selected `ProblemVariant`)
 - Base function `build_model(problem::ProblemGenerator)` that each variant implements
 
+**Model transforms** (`src/transforms.jl`):
+- Post-`build_model` reformulations of the finished JuMP model, applied centrally in `generate_problem()` (not per-variant), exactly like `relax_integrality`.
+- `bounds_to_constraints!(model)`: reformulates variable bounds as explicit affine constraints, keeping a plain `x ≥ 0` nonnegativity bound but converting all other bounds (upper, fixed, nonzero lower). Exposed everywhere as the keyword `bounds_to_constraints::Bool=false` on `generate_problem()`/`generate_random_problem()`/`generate_dataset()` (and `--bounds-to-constraints` on both CLI scripts). Runs *after* `relax_integer`, so relaxation-introduced bounds are converted too. Converted bounds become genuine rows, so they raise `num_constraints(...; count_variable_in_set_constraints=false)` and thus affect dataset size-matching and quality-filter thresholds.
+
 **Dataset Generation** (`src/dataset.jl`):
 - `generate_dataset(; kwargs...)`: builds a whole dataset of LP instances by sampling problem types and target variable counts; optionally writes instance files + a `manifest.json` and returns `Vector{GeneratedInstance}` metadata. Fully reproducible from a non-zero `seed`.
 - `check_quality(model, optimizer; ...)` + `QualityCriteria`/`QualityResult`: solve-based filtering of trivial/degenerate/unbounded/ill-conditioned instances.

--- a/README.md
+++ b/README.md
@@ -122,6 +122,27 @@ model, problem = generate_problem(:diet_problem, 100, infeasible, 0)
 model, problem = generate_problem(:portfolio, 100, unknown, 0)
 ```
 
+### Bound Reformulation
+
+By default, variable bounds are emitted as JuMP/MOI variable bounds. Pass
+`bounds_to_constraints=true` to instead reformulate them as explicit affine
+constraints — useful for generating LPs in a more standard-form-like shape.
+A plain `x ≥ 0` nonnegativity bound is left as a variable bound; every other
+bound (upper bounds, fixed values, and nonzero lower bounds) becomes a row.
+
+```julia
+# Bounds (other than x ≥ 0) become explicit constraint rows
+model, problem = generate_problem(:knapsack, 100, unknown, 0; bounds_to_constraints=true)
+
+# Or apply it to an already-built JuMP model in place
+bounds_to_constraints!(model)
+```
+
+The reformulation runs *after* integrality relaxation, so bounds introduced by
+relaxing integer/binary variables (e.g. `0 ≤ x ≤ 1`) are converted too. Because
+the converted bounds become genuine rows, they are now counted by
+`num_constraints(model; count_variable_in_set_constraints=false)`.
+
 ### Reproducible Generation with Seeds
 
 ```julia
@@ -346,6 +367,9 @@ julia --project=@. scripts/generate_problem.jl knapsack 50 --feasible --solve
 # Generate an infeasible diet problem with ~100 variables
 julia --project=@. scripts/generate_problem.jl diet_problem 100 --infeasible output.mps
 
+# Reformulate variable bounds (other than x >= 0) into explicit constraints
+julia --project=@. scripts/generate_problem.jl knapsack 50 --bounds-to-constraints
+
 # Generate a random problem with ~200 variables
 julia --project=@. scripts/generate_problem.jl random 200
 
@@ -368,6 +392,9 @@ julia --project=scripts scripts/generate_lps.jl -o output -n 50 --feasible-only 
 
 # Restrict to specific problem types and a fixed seed
 julia --project=scripts scripts/generate_lps.jl --problem-types transportation,knapsack -n 20 --seed 42
+
+# Reformulate variable bounds (other than x >= 0) into explicit constraints
+julia --project=scripts scripts/generate_lps.jl -o output -n 20 --bounds-to-constraints
 
 # Uniform actual-size matching for each selected problem type
 julia --project=scripts scripts/generate_lps.jl -o output -n 60 \

--- a/scripts/generate_lps.jl
+++ b/scripts/generate_lps.jl
@@ -71,6 +71,9 @@ function parse_commandline()
         "--feasible-only"
             help = "Only generate problems guaranteed to be feasible"
             action = :store_true
+        "--bounds-to-constraints"
+            help = "Reformulate variable bounds (other than x >= 0) as explicit affine constraints"
+            action = :store_true
         "--problem-types"
             help = "Comma-separated list of categories (e.g. transportation) or " *
                    "category/variant references (e.g. portfolio/cvar) to sample " *
@@ -151,6 +154,7 @@ function main()
         size_distribution = size_distribution,
         problem_types = problem_types,
         feasible_only = args["feasible-only"],
+        bounds_to_constraints = args["bounds-to-constraints"],
         seed = args["seed"],
         match_size_distribution = !args["no-size-matching"],
         match_size_by_type = args["match-size-by-type"],

--- a/scripts/generate_problem.jl
+++ b/scripts/generate_problem.jl
@@ -10,6 +10,7 @@
 #   julia --project=@. scripts/generate_problem.jl portfolio/cvar 100 problem.mps
 #   julia --project=@. scripts/generate_problem.jl knapsack 50 --feasible --solve
 #   julia --project=@. scripts/generate_problem.jl diet_problem 100 --infeasible
+#   julia --project=@. scripts/generate_problem.jl knapsack 50 --bounds-to-constraints
 #   julia --project=@. scripts/generate_problem.jl list
 
 using Pkg
@@ -28,9 +29,13 @@ target_variables = length(ARGS) >= 2 ? parse(Int, ARGS[2]) : 50
 output_file = nothing
 feasibility_status = unknown
 seed = 0
+bounds_to_constraints = false
 
-# Parse optional arguments
+# Parse optional arguments. `global` is required because this loop runs at the
+# script's top level (soft scope), so assignments would otherwise create locals
+# and silently leave these globals at their defaults.
 for arg in ARGS[3:end]
+    global feasibility_status, seed, output_file, bounds_to_constraints
     if arg == "--solve"
         # Handled later
     elseif arg == "--feasible"
@@ -39,6 +44,8 @@ for arg in ARGS[3:end]
         feasibility_status = infeasible
     elseif arg == "--unknown"
         feasibility_status = unknown
+    elseif arg == "--bounds-to-constraints"
+        bounds_to_constraints = true
     elseif startswith(arg, "--seed=")
         seed = parse(Int, split(arg, "=")[2])
     elseif !startswith(arg, "--")
@@ -60,7 +67,7 @@ if problem_arg == "list"
 elseif problem_arg == "random"
     println("Generating a random problem targeting ~$target_variables variables")
     println("Feasibility status: $feasibility_status")
-    model, selected_ref, problem = generate_random_problem(target_variables; feasibility_status=feasibility_status, seed=seed)
+    model, selected_ref, problem = generate_random_problem(target_variables; feasibility_status=feasibility_status, bounds_to_constraints=bounds_to_constraints, seed=seed)
     println("Problem selected: $selected_ref")
 else
     # Accept a category (default variant) or an explicit `category/variant`.
@@ -86,7 +93,7 @@ else
 
     println("Generating $ref problem targeting ~$target_variables variables")
     println("Feasibility status: $feasibility_status")
-    model, problem = generate_problem(ref, target_variables, feasibility_status, seed)
+    model, problem = generate_problem(ref, target_variables, feasibility_status, seed; bounds_to_constraints=bounds_to_constraints)
 end
 
 # Print summary

--- a/src/SyntheticLPs.jl
+++ b/src/SyntheticLPs.jl
@@ -27,6 +27,7 @@ export list_problem_types
 export list_variants
 export list_problems
 export problem_info
+export bounds_to_constraints!
 export generate_dataset
 export GeneratedInstance
 export QualityCriteria, QualityResult, check_quality
@@ -216,6 +217,11 @@ get_problem_type(category::Symbol) = get_problem_type(ProblemVariant(category))
 get_problem_type(s::AbstractString) = get_problem_type(ProblemVariant(s))
 
 # ---------------------------------------------------------------------------
+# Model transforms (post-build reformulations)
+# ---------------------------------------------------------------------------
+include("transforms.jl")
+
+# ---------------------------------------------------------------------------
 # Model building and problem generation
 # ---------------------------------------------------------------------------
 
@@ -234,10 +240,16 @@ Each variant must implement this method.
 function build_model end
 
 """
-    generate_problem(::Type{T}, target_variables, feasibility_status, seed; relax_integer=true)
+    generate_problem(::Type{T}, target_variables, feasibility_status, seed;
+                     relax_integer=true, bounds_to_constraints=false)
 
 Generate a linear programming problem from a generator type by constructing an
 instance and building its model.
+
+When `bounds_to_constraints=true`, variable bounds (other than plain `x ≥ 0`
+nonnegativity) are reformulated as explicit affine constraints via
+[`bounds_to_constraints!`](@ref). This runs *after* integrality relaxation, so
+bounds introduced by relaxing integer/binary variables are converted too.
 
 # Returns
 - `model`: The JuMP model
@@ -245,7 +257,8 @@ instance and building its model.
 """
 function generate_problem(::Type{T}, target_variables::Int,
                           feasibility_status::FeasibilityStatus=unknown, seed::Int=0;
-                          relax_integer::Bool=true) where T <: ProblemGenerator
+                          relax_integer::Bool=true,
+                          bounds_to_constraints::Bool=false) where T <: ProblemGenerator
     problem = T(target_variables, feasibility_status, seed)
     model = build_model(problem)
 
@@ -253,37 +266,45 @@ function generate_problem(::Type{T}, target_variables::Int,
         relax_integrality(model)
     end
 
+    if bounds_to_constraints
+        bounds_to_constraints!(model)
+    end
+
     return model, problem
 end
 
 """
-    generate_problem(ref::ProblemVariant, target_variables, feasibility_status, seed; relax_integer=true)
+    generate_problem(ref::ProblemVariant, target_variables, feasibility_status, seed;
+                     relax_integer=true, bounds_to_constraints=false)
 
 Generate a problem from a fully-qualified `category/variant` reference.
 """
 function generate_problem(ref::ProblemVariant, target_variables::Int,
                           feasibility_status::FeasibilityStatus=unknown, seed::Int=0;
-                          relax_integer::Bool=true)
+                          relax_integer::Bool=true, bounds_to_constraints::Bool=false)
     return generate_problem(get_problem_type(ref), target_variables,
-                            feasibility_status, seed; relax_integer=relax_integer)
+                            feasibility_status, seed; relax_integer=relax_integer,
+                            bounds_to_constraints=bounds_to_constraints)
 end
 
 """
-    generate_problem(ref::AbstractString, target_variables, feasibility_status, seed; relax_integer=true)
+    generate_problem(ref::AbstractString, target_variables, feasibility_status, seed;
+                     relax_integer=true, bounds_to_constraints=false)
 
 Generate a problem from a `"category"` or `"category/variant"` string, parsed via
 [`ProblemVariant`](@ref).
 """
 function generate_problem(ref::AbstractString, target_variables::Int,
                           feasibility_status::FeasibilityStatus=unknown, seed::Int=0;
-                          relax_integer::Bool=true)
+                          relax_integer::Bool=true, bounds_to_constraints::Bool=false)
     return generate_problem(ProblemVariant(ref), target_variables,
-                            feasibility_status, seed; relax_integer=relax_integer)
+                            feasibility_status, seed; relax_integer=relax_integer,
+                            bounds_to_constraints=bounds_to_constraints)
 end
 
 """
     generate_problem(category::Symbol, target_variables, feasibility_status, seed;
-                     variant=nothing, relax_integer=true)
+                     variant=nothing, relax_integer=true, bounds_to_constraints=false)
 
 Generate a problem for a category. With `variant=nothing` the category's default
 variant is used; pass `variant=:name` to select a specific variant.
@@ -294,6 +315,9 @@ variant is used; pass `variant=:name` to select a specific variant.
 - `feasibility_status`: Desired feasibility status (feasible, infeasible, or unknown)
 - `seed`: Random seed for reproducibility
 - `variant`: Optional variant symbol; defaults to the category default
+- `relax_integer`: Relax integrality of the generated model
+- `bounds_to_constraints`: Reformulate variable bounds (other than `x ≥ 0`) as
+  explicit affine constraints
 
 # Returns
 - `model`: The JuMP model
@@ -301,11 +325,13 @@ variant is used; pass `variant=:name` to select a specific variant.
 """
 function generate_problem(category::Symbol, target_variables::Int,
                           feasibility_status::FeasibilityStatus=unknown, seed::Int=0;
-                          variant::Union{Symbol,Nothing}=nothing, relax_integer::Bool=true)
+                          variant::Union{Symbol,Nothing}=nothing, relax_integer::Bool=true,
+                          bounds_to_constraints::Bool=false)
     ref = variant === nothing ? ProblemVariant(category) :
                                 ProblemVariant(category, variant)
     return generate_problem(ref, target_variables, feasibility_status, seed;
-                            relax_integer=relax_integer)
+                            relax_integer=relax_integer,
+                            bounds_to_constraints=bounds_to_constraints)
 end
 
 # ---------------------------------------------------------------------------
@@ -380,7 +406,8 @@ function problem_info(category::Symbol, variant::Symbol)
 end
 
 """
-    generate_random_problem(target_variables; feasibility_status=unknown, relax_integer=true, seed=0)
+    generate_random_problem(target_variables; feasibility_status=unknown,
+                            relax_integer=true, bounds_to_constraints=false, seed=0)
 
 Generate a problem of a randomly selected variant targeting approximately the
 specified number of variables. Sampling is uniform over all registered
@@ -393,7 +420,8 @@ specified number of variables. Sampling is uniform over all registered
 """
 function generate_random_problem(target_variables::Int;
                                  feasibility_status::FeasibilityStatus=unknown,
-                                 relax_integer::Bool=true, seed::Int=0)
+                                 relax_integer::Bool=true,
+                                 bounds_to_constraints::Bool=false, seed::Int=0)
     Random.seed!(seed)
 
     problems = list_problems()
@@ -403,7 +431,8 @@ function generate_random_problem(target_variables::Int;
 
     ref = rand(problems)
     model, problem = generate_problem(ref, target_variables, feasibility_status, seed;
-                                      relax_integer=relax_integer)
+                                      relax_integer=relax_integer,
+                                      bounds_to_constraints=bounds_to_constraints)
 
     return model, ref, problem
 end

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -465,6 +465,7 @@ function _attempt_candidate(rng::AbstractRNG,
                             target_vars::Int,
                             feasibility::FeasibilityStatus,
                             relax_integer::Bool,
+                            bounds_to_constraints::Bool,
                             quality_filter::Bool,
                             optimizer,
                             quality_criteria::QualityCriteria,
@@ -475,7 +476,8 @@ function _attempt_candidate(rng::AbstractRNG,
     problem_seed = rand(rng, 1:typemax(Int32))
     try
         model, _ = generate_problem(ref, target_vars, feasibility,
-                                    problem_seed; relax_integer = relax_integer)
+                                    problem_seed; relax_integer = relax_integer,
+                                    bounds_to_constraints = bounds_to_constraints)
 
         iterations = -1
         stime = NaN
@@ -532,6 +534,7 @@ function _fill_candidate_pool!(candidates::Vector{_DatasetCandidate},
                                size_spec::_SizeDistributionSpec,
                                feasibility::FeasibilityStatus,
                                relax_integer::Bool,
+                               bounds_to_constraints::Bool,
                                quality_filter::Bool,
                                optimizer,
                                quality_criteria::QualityCriteria,
@@ -547,7 +550,8 @@ function _fill_candidate_pool!(candidates::Vector{_DatasetCandidate},
         target_vars = _candidate_target_variables(rng, size_spec, quota,
                                                   target_index_start + local_attempts - 1)
         candidate = _attempt_candidate(rng, ref, target_vars, feasibility,
-                                       relax_integer, quality_filter, optimizer,
+                                       relax_integer, bounds_to_constraints,
+                                       quality_filter, optimizer,
                                        quality_criteria, optimizer_attributes,
                                        feasible_only, stats, verbose)
         candidate === nothing || push!(candidates, candidate)
@@ -581,6 +585,7 @@ function _generate_matched_group(rng::AbstractRNG,
                                  size_spec::_SizeDistributionSpec,
                                  feasibility::FeasibilityStatus,
                                  relax_integer::Bool,
+                                 bounds_to_constraints::Bool,
                                  quality_filter::Bool,
                                  optimizer,
                                  quality_criteria::QualityCriteria,
@@ -606,8 +611,8 @@ function _generate_matched_group(rng::AbstractRNG,
             group_attempts += _fill_candidate_pool!(
                 candidates, rng, group_variants, quota, desired_count,
                 group_attempts, remaining_attempts, size_spec, feasibility,
-                relax_integer, quality_filter, optimizer, quality_criteria,
-                optimizer_attributes, feasible_only, stats, verbose)
+                relax_integer, bounds_to_constraints, quality_filter, optimizer,
+                quality_criteria, optimizer_attributes, feasible_only, stats, verbose)
         end
 
         if length(candidates) < quota
@@ -640,6 +645,7 @@ function _generate_unmatched_candidates(rng::AbstractRNG,
                                         size_spec::_SizeDistributionSpec,
                                         feasibility::FeasibilityStatus,
                                         relax_integer::Bool,
+                                        bounds_to_constraints::Bool,
                                         quality_filter::Bool,
                                         optimizer,
                                         quality_criteria::QualityCriteria,
@@ -657,7 +663,8 @@ function _generate_unmatched_candidates(rng::AbstractRNG,
         ref = rand(rng, types)
         target_vars = _sample_num_variables(rng, size_spec)
         candidate = _attempt_candidate(rng, ref, target_vars, feasibility,
-                                       relax_integer, quality_filter, optimizer,
+                                       relax_integer, bounds_to_constraints,
+                                       quality_filter, optimizer,
                                        quality_criteria, optimizer_attributes,
                                        feasible_only, stats, verbose)
         candidate === nothing || push!(candidates, candidate)
@@ -701,6 +708,7 @@ function _materialize_instances(candidates::Vector{_DatasetCandidate},
                                 file_extension::AbstractString,
                                 feasibility::FeasibilityStatus,
                                 relax_integer::Bool,
+                                bounds_to_constraints::Bool,
                                 verbose::Bool)
     instances = GeneratedInstance[]
     for (idx, candidate) in enumerate(candidates)
@@ -711,7 +719,8 @@ function _materialize_instances(candidates::Vector{_DatasetCandidate},
                                         candidate.target_variables,
                                         feasibility,
                                         candidate.seed;
-                                        relax_integer = relax_integer)
+                                        relax_integer = relax_integer,
+                                        bounds_to_constraints = bounds_to_constraints)
             actual_vars = num_variables(model)
             actual_cons = num_constraints(model; count_variable_in_set_constraints = false)
             if actual_vars != candidate.num_variables || actual_cons != candidate.num_constraints
@@ -788,6 +797,11 @@ Returns metadata for every kept instance as a `Vector{GeneratedInstance}`.
   (`nothing`/empty = all registered types).
 - `feasible_only::Bool = false`: request guaranteed-feasible instances.
 - `relax_integer::Bool = true`: relax integrality of generated models.
+- `bounds_to_constraints::Bool = false`: reformulate variable bounds (other than
+  plain `x ≥ 0` nonnegativity) as explicit affine constraints. Applied after
+  integrality relaxation. Note: converted bounds become genuine constraint rows,
+  so they raise the `num_constraints` recorded for each instance and feed into
+  size matching and the quality filter's constraint-based thresholds.
 - `seed::Int = 0`: master seed (`0` = non-deterministic).
 - `match_size_distribution::Bool = true`: post-select candidates so actual
   variable counts match target distribution quantiles.
@@ -831,6 +845,7 @@ function generate_dataset(;
         problem_types = nothing,
         feasible_only::Bool = false,
         relax_integer::Bool = true,
+        bounds_to_constraints::Bool = false,
         seed::Int = 0,
         match_size_distribution::Bool = true,
         match_size_by_type::Bool = false,
@@ -878,6 +893,7 @@ function generate_dataset(;
         println("  Size matching: $(match_size_distribution ? "enabled" : "disabled")" *
                 (match_size_by_type ? " (per type)" : ""))
         println("  Feasibility: $(feasible_only ? "feasible only" : "unknown")")
+        bounds_to_constraints && println("  Bounds → constraints: enabled")
         println("  Problem types: $(length(types))")
         if quality_filter
             println("  Quality filter: enabled (timeout=$(quality_criteria.solve_timeout)s, " *
@@ -914,6 +930,7 @@ function generate_dataset(;
                 size_spec,
                 feasibility,
                 relax_integer,
+                bounds_to_constraints,
                 quality_filter,
                 optimizer,
                 quality_criteria,
@@ -942,6 +959,7 @@ function generate_dataset(;
             size_spec,
             feasibility,
             relax_integer,
+            bounds_to_constraints,
             quality_filter,
             optimizer,
             quality_criteria,
@@ -968,6 +986,7 @@ function generate_dataset(;
             size_spec,
             feasibility,
             relax_integer,
+            bounds_to_constraints,
             quality_filter,
             optimizer,
             quality_criteria,
@@ -982,7 +1001,7 @@ function generate_dataset(;
     shuffle!(rng, selected_candidates)
     instances = _materialize_instances(selected_candidates, output_dir,
                                        file_extension, feasibility,
-                                       relax_integer, verbose)
+                                       relax_integer, bounds_to_constraints, verbose)
 
     size_match_report = Dict{String,Any}(
         "enabled" => match_size_distribution,
@@ -1000,7 +1019,9 @@ function generate_dataset(;
         _write_manifest(output_dir, instances, types; seed = seed,
                         var_mean = var_mean, var_std = var_std,
                         var_min = var_min, var_max = var_max,
-                        feasible_only = feasible_only, quality_filter = quality_filter,
+                        feasible_only = feasible_only,
+                        bounds_to_constraints = bounds_to_constraints,
+                        quality_filter = quality_filter,
                         quality_criteria = quality_criteria,
                         attempts = stats.attempts, failed = stats.failed,
                         filter_counts = stats.filter_counts,

--- a/src/transforms.jl
+++ b/src/transforms.jl
@@ -1,0 +1,45 @@
+# Model-level reformulations applied to a built JuMP model.
+#
+# These transforms operate on the finished model produced by `build_model`,
+# so they apply uniformly to every category/variant without each generator
+# having to implement them. They are the bounds-to-constraints counterpart of
+# JuMP's `relax_integrality`, and are wired into `generate_problem` the same way.
+
+"""
+    bounds_to_constraints!(model)
+
+Reformulate variable bounds as explicit affine constraints. A plain `x ≥ 0`
+nonnegativity lower bound is left as a variable bound; all other bounds
+(upper bounds, fixed values, and nonzero lower bounds) become affine rows and
+the corresponding variable bound is removed.
+
+In MOI, variable bounds are stored as variable-in-set constraints, which is why
+they are excluded by `num_constraints(model; count_variable_in_set_constraints=false)`.
+After this transform the converted bounds are genuine affine constraints and so
+*are* counted there.
+
+Returns the (mutated) `model`.
+"""
+function bounds_to_constraints!(model::Model)
+    for x in all_variables(model)
+        if is_fixed(x)
+            v = fix_value(x)
+            unfix(x)
+            @constraint(model, x == v)
+        else
+            if has_lower_bound(x)
+                lb = lower_bound(x)
+                if lb != 0  # keep standard nonnegativity as a variable bound
+                    delete_lower_bound(x)
+                    @constraint(model, x >= lb)
+                end
+            end
+            if has_upper_bound(x)
+                ub = upper_bound(x)
+                delete_upper_bound(x)
+                @constraint(model, x <= ub)
+            end
+        end
+    end
+    return model
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -265,4 +265,61 @@ end
         @test crit.min_constraints == 10
         @test crit.min_iterations == 5
     end
+
+    # Test the bounds-to-constraints reformulation
+    @testset "Bounds to Constraints" begin
+        # Direct transform on a hand-built model exercising every bound kind.
+        m = Model()
+        @variable(m, x >= 0)        # plain nonnegativity — preserved
+        @variable(m, 2 <= y <= 5)   # nonzero lower + upper — both become rows
+        @variable(m, z == 3)        # fixed — becomes an equality row
+        @variable(m, w <= 7)        # upper only — becomes a row
+        @objective(m, Max, x + y + z + w)
+        @constraint(m, x + y + z + w <= 100)
+
+        aff_before = num_constraints(m; count_variable_in_set_constraints = false)
+        result = bounds_to_constraints!(m)
+        @test result === m  # mutates and returns the same model
+        aff_after = num_constraints(m; count_variable_in_set_constraints = false)
+
+        # +4 rows: lower(y), upper(y), fixed(z), upper(w). x ≥ 0 is left alone.
+        @test aff_after == aff_before + 4
+
+        # Nonnegativity is preserved; all other bounds are stripped.
+        @test has_lower_bound(x)
+        @test !has_lower_bound(y)
+        @test !has_upper_bound(y)
+        @test !is_fixed(z)
+        @test !has_upper_bound(w)
+
+        # The variable count is unchanged by the reformulation.
+        @test num_variables(m) == 4
+
+        # Via generate_problem: every item in knapsack/bounded carries an upper
+        # bound (0 ≤ x ≤ uᵢ), so converting adds affine rows without changing the
+        # variable count. (Integrality is relaxed by default before conversion.)
+        ref = ProblemVariant("knapsack/bounded")
+        m_plain, _ = generate_problem(ref, 100, unknown, 0)
+        m_conv, _  = generate_problem(ref, 100, unknown, 0; bounds_to_constraints = true)
+        @test num_variables(m_conv) == num_variables(m_plain)
+        @test num_constraints(m_conv; count_variable_in_set_constraints = false) >
+              num_constraints(m_plain; count_variable_in_set_constraints = false)
+
+        # generate_dataset threads the option through: converted bounds raise the
+        # recorded constraint counts, and the choice is recorded in the manifest.
+        tmp = mktempdir()
+        plain = generate_dataset(num_problems = 4, var_mean = 80, var_std = 20,
+                                 var_min = 30, var_max = 150, seed = 21,
+                                 problem_types = ["knapsack/bounded"],
+                                 max_candidate_multiplier = 2)
+        converted = generate_dataset(num_problems = 4, var_mean = 80, var_std = 20,
+                                     var_min = 30, var_max = 150, seed = 21,
+                                     problem_types = ["knapsack/bounded"],
+                                     max_candidate_multiplier = 2,
+                                     bounds_to_constraints = true,
+                                     output_dir = tmp)
+        @test sum(i -> i.num_constraints, converted) > sum(i -> i.num_constraints, plain)
+        manifest = JSON.parsefile(joinpath(tmp, "manifest.json"))
+        @test manifest["config"]["bounds_to_constraints"] == true
+    end
 end


### PR DESCRIPTION
## Summary

Adds an opt-in `bounds_to_constraints` reformulation that rewrites variable bounds as explicit affine constraints, following the exact pattern of the existing `relax_integer` option. Default is `false`, so the generated corpus is byte-identical when the option is unused.

- **New file `src/transforms.jl`** — `bounds_to_constraints!(model)` walks every variable and converts its bounds to rows: a fixed value becomes an equality row; an upper bound and a *nonzero* lower bound become inequality rows; the corresponding variable bound is removed. A plain `x ≥ 0` nonnegativity bound is left as a variable bound (standard form), so only the "interesting" bounds are moved.
- **Wiring** — `bounds_to_constraints::Bool=false` keyword added to all four `generate_problem` methods, `generate_random_problem`, and `generate_dataset` (threaded through its candidate/materialize helpers alongside `relax_integer`). Applied *after* integrality relaxation, so bounds introduced by relaxing integer/binary variables (e.g. `0 ≤ x ≤ 1`) are converted too. Recorded in the dataset `manifest.json` config and verbose output.
- **CLI** — `--bounds-to-constraints` flag on both `scripts/generate_problem.jl` and `scripts/generate_lps.jl`.

## Intended side effect

Converted bounds become genuine constraint rows, so they are now counted by `num_constraints(model; count_variable_in_set_constraints=false)`. This raises the recorded `num_constraints` per instance and therefore feeds into dataset size-matching and the quality filter's constraint-based thresholds (`min_constraints`, `max_iteration_ratio`).

## Bonus bug fix

While wiring the CLI flag, I found a pre-existing soft-scope bug in `scripts/generate_problem.jl`: its argument-parsing loop assigned to locals instead of globals, so `--feasible`/`--infeasible`/`--unknown`, `--seed=`, and the output-file positional were **all silently ignored**. Added the required `global` declaration; these flags now take effect.

## Testing

- New `Bounds to Constraints` testset: direct structural checks on `bounds_to_constraints!` (nonnegativity preserved, correct number of rows added, variable count unchanged), plus `generate_problem` and `generate_dataset` integration (constraint counts increase, manifest flag set).
- Suite now **2460 passing** assertions (up from 2448). The 6 remaining failures are pre-existing variable-count-tolerance checks in generators untouched by this PR — confirmed identical on clean `main`.
- Smoke-tested both CLIs end-to-end: `knapsack/bounded` goes from 1 → 51 constraints with the flag enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)